### PR TITLE
docs: Also update 03 step of 04-logic with correct bounds

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/04-logic/03-else-if-blocks/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/04-logic/03-else-if-blocks/index.md
@@ -11,6 +11,6 @@ Multiple conditions can be 'chained' together with `else if`:
 +++{:else if count < 5}
 	<p>{count} is less than 5</p>+++
 {:else}
-	<p>{count} is between +++5+++ and 10</p>
+	<p>{count} is between +++5+++ and 11</p>
 {/if}
 ```


### PR DESCRIPTION
Minor fix: The else clause suggested by the tutorial will happily display that `10 is between 0 and 10`. To be between 0 and 10 implies `> 0` and `< 10`, so when the counter is `10` the statement is incorrect.